### PR TITLE
修改领取记录里的列排序，增加项目内容文本的双击复制，避免因项目内容文本太长带来不好的交互体验

### DIFF
--- a/frontend/components/common/received/DataTable.tsx
+++ b/frontend/components/common/received/DataTable.tsx
@@ -276,6 +276,15 @@ export function DataTable({data}: DataTableProps) {
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-[10px]">
+                <button
+                  className="font-medium hover:text-primary transition-colors"
+                  onClick={() => handleSort('received_at')}
+                >
+                  领取时间{renderSortIcon('received_at')}
+                </button>
+              </TableHead>
+              <TableHead className="text-right w-[60px]"></TableHead>
               <TableHead className="w-[120px]">
                 <button
                   className="font-medium hover:text-primary transition-colors"
@@ -300,15 +309,6 @@ export function DataTable({data}: DataTableProps) {
                   项目内容{renderSortIcon('content')}
                 </button>
               </TableHead>
-              <TableHead className="w-[10px]">
-                <button
-                  className="font-medium hover:text-primary transition-colors"
-                  onClick={() => handleSort('received_at')}
-                >
-                  领取时间{renderSortIcon('received_at')}
-                </button>
-              </TableHead>
-              <TableHead className="text-right w-[60px]"></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -325,6 +325,22 @@ export function DataTable({data}: DataTableProps) {
             ) : (
               paginatedData.map((item) => (
                 <TableRow key={`${item.project_id}-${item.received_at}`}>
+                  <TableCell className="text-xs text-gray-600 dark:text-gray-400">
+                    {item.received_at ? formatDateTimeWithSeconds(item.received_at) : '-'}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end space-x-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openProjectDetail(item.project_id)}
+                        className="h-6 w-6 p-0"
+                        title="查看详情"
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </TableCell>
                   <TableCell>
                     <div>
                       <span
@@ -346,7 +362,10 @@ export function DataTable({data}: DataTableProps) {
                     </Link>
                   </TableCell>
                   <TableCell className="text-xs font-mono text-gray-600 dark:text-gray-400">
-                    <div className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-sm flex items-center justify-between group hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
+                    <div className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-sm flex items-center justify-between group hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                      onDoubleClick={() => copyToClipboard(item.content)}
+                      title="双击复制内容"
+                    >
                       <div className="flex-1 min-w-0">
                         {item.content}
                       </div>
@@ -358,22 +377,6 @@ export function DataTable({data}: DataTableProps) {
                         title="复制项目内容"
                       >
                         <Copy className="h-3 w-3" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-xs text-gray-600 dark:text-gray-400">
-                    {item.received_at ? formatDateTimeWithSeconds(item.received_at) : '-'}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex justify-end space-x-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => openProjectDetail(item.project_id)}
-                        className="h-6 w-6 p-0"
-                        title="查看详情"
-                      >
-                        <ExternalLink className="h-3 w-3" />
                       </Button>
                     </div>
                   </TableCell>


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/cdk/blob/master/CODE_OF_CONDUCT.md)，  
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/cdk/blob/master/CLA.md)，确认我的贡献将根据项目的 MIT 许可证进行许可，  
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并，

**关联信息**

<!--
如此 PR 解决了一个 Issue, 请在下方填写
resolves #<issue_number>，例如：
resolves #1234
-->
resolves #104

<!-- 若以上均没有，请删除此节 -->

**变更内容**

<!-- 请在下方简要描述此 PR 的变更内容 -->
1. 调整列排序，将领取时间调整为第一列
2. 对项目内容添加双击复制的交互功能

**变更原因**

<!-- 请在下方简要描述此 PR 的变更原因 -->
1. 项目内容虽然有限制列宽，但是240px还是太长了，导致领取时间列里的跳转详情往往需要拖动左右滚动条才能滑动到，来回拖动容易造成不便
2. 项目复制图标同上，需要滑动才能点击复制，增加双击文本复制有利于快速复制，提升交互体验