### PR TITLE
feat(observability): propagate request ids through logs and API errors

### DIFF
--- a/frontend/lib/services/core/api-client.ts
+++ b/frontend/lib/services/core/api-client.ts
@@ -1,5 +1,10 @@
 import axios, {AxiosError, AxiosResponse} from 'axios';
 import {ApiError, ApiResponse} from './types';
+import {
+  createApiClientError,
+  createApiClientErrorFromResponse,
+  extractRequestId,
+} from './api-error';
 
 /**
  * API客户端实例
@@ -31,7 +36,10 @@ apiClient.interceptors.request.use(
  */
 function initiateLogin(currentPath: string): Promise<never> {
   // 防止循环重定向
-  if (!currentPath.startsWith('/login') && !currentPath.startsWith('/callback')) {
+  if (
+    !currentPath.startsWith('/login') &&
+    !currentPath.startsWith('/callback')
+  ) {
     // 动态导入AuthService避免循环依赖
     import('../auth/auth.service').then(({AuthService}) => {
       // 直接调用登录方法，传入当前路径作为重定向目标
@@ -55,29 +63,54 @@ apiClient.interceptors.response.use(
         return initiateLogin(window.location.pathname);
       }
 
+      const requestId = extractRequestId(error.response);
+
       // 处理后端返回的错误信息
       if (error.response?.data?.error_msg) {
-        const apiError = new Error(error.response.data.error_msg);
-        apiError.name = 'ApiError';
-        return Promise.reject(apiError);
+        return Promise.reject(
+            createApiClientErrorFromResponse(
+                error.response.data.error_msg,
+                error.response,
+            ),
+        );
       }
 
       // 处理网络错误
       if (error.code === 'ECONNABORTED') {
-        return Promise.reject(new Error('请求超时，请检查网络连接'));
+        return Promise.reject(
+            createApiClientError('请求超时，请检查网络连接', {
+              requestId,
+              status: error.response?.status,
+            }),
+        );
       }
 
       // 处理权限错误
       if (error.response?.status === 403) {
-        return Promise.reject(new Error('权限不足'));
+        return Promise.reject(
+            createApiClientError('权限不足', {
+              requestId,
+              status: error.response.status,
+            }),
+        );
       }
 
       // 处理服务器错误
       if (error.response && error.response.status >= 500) {
-        return Promise.reject(new Error('服务器内部错误，请稍后重试'));
+        return Promise.reject(
+            createApiClientError('服务器内部错误，请稍后重试', {
+              requestId,
+              status: error.response.status,
+            }),
+        );
       }
 
-      return Promise.reject(new Error(error.message || '网络请求失败'));
+      return Promise.reject(
+          createApiClientError(error.message || '网络请求失败', {
+            requestId,
+            status: error.response?.status,
+          }),
+      );
     },
 );
 

--- a/frontend/lib/services/core/api-error.ts
+++ b/frontend/lib/services/core/api-error.ts
@@ -1,0 +1,66 @@
+import {AxiosResponse} from 'axios';
+import {ApiResponse} from './types';
+
+export class ApiClientError extends Error {
+  requestId?: string;
+  status?: number;
+
+  constructor(
+      message: string,
+      options: { requestId?: string; status?: number } = {},
+  ) {
+    super(appendRequestId(message, options.requestId));
+    this.name = 'ApiClientError';
+    this.requestId = options.requestId;
+    this.status = options.status;
+  }
+}
+
+export const appendRequestId = (
+    message: string,
+    requestId?: string,
+): string => {
+  if (!requestId) {
+    return message;
+  }
+
+  return `${message} (Request ID: ${requestId})`;
+};
+
+export const extractRequestId = (
+    response?: Pick<AxiosResponse, 'headers'>,
+): string | undefined => {
+  const headerValue = response?.headers?.['x-request-id'];
+
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  if (typeof headerValue === 'string' && headerValue.trim()) {
+    return headerValue.trim();
+  }
+
+  return undefined;
+};
+
+export const createApiClientError = (
+    message: string,
+    options: { requestId?: string; status?: number } = {},
+): ApiClientError => new ApiClientError(message, options);
+
+export const createApiClientErrorFromResponse = (
+    message: string,
+    response?: Pick<AxiosResponse, 'headers' | 'status'>,
+): ApiClientError =>
+  createApiClientError(message, {
+    requestId: extractRequestId(response),
+    status: response?.status,
+  });
+
+export const throwIfApiResponseError = <T>(
+  response: AxiosResponse<ApiResponse<T>>,
+): void => {
+  if (response.data.error_msg) {
+    throw createApiClientErrorFromResponse(response.data.error_msg, response);
+  }
+};

--- a/frontend/lib/services/core/base.service.ts
+++ b/frontend/lib/services/core/base.service.ts
@@ -1,5 +1,7 @@
+import {AxiosResponse} from 'axios';
 import apiClient from './api-client';
 import {ApiResponse} from './types';
+import {throwIfApiResponseError} from './api-error';
 
 /**
  * 服务基类
@@ -19,6 +21,13 @@ export abstract class BaseService {
     return `${this.basePath}${path}`;
   }
 
+  protected static unwrapApiResponse<T>(
+      response: AxiosResponse<ApiResponse<T>>,
+  ): T {
+    throwIfApiResponseError(response);
+    return response.data.data;
+  }
+
   /**
    * GET请求
    * @template T - 响应数据类型
@@ -26,9 +35,15 @@ export abstract class BaseService {
    * @param params - 查询参数
    * @returns 响应数据
    */
-  protected static async get<T>(path: string, params?: Record<string, unknown>): Promise<T> {
-    const response = await apiClient.get<ApiResponse<T>>(this.getFullPath(path), {params});
-    return response.data.data;
+  protected static async get<T>(
+      path: string,
+      params?: Record<string, unknown>,
+  ): Promise<T> {
+    const response = await apiClient.get<ApiResponse<T>>(
+        this.getFullPath(path),
+        {params},
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -39,8 +54,11 @@ export abstract class BaseService {
    * @returns 响应数据
    */
   protected static async post<T>(path: string, data?: unknown): Promise<T> {
-    const response = await apiClient.post<ApiResponse<T>>(this.getFullPath(path), data);
-    return response.data.data;
+    const response = await apiClient.post<ApiResponse<T>>(
+        this.getFullPath(path),
+        data,
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -51,8 +69,11 @@ export abstract class BaseService {
    * @returns 响应数据
    */
   protected static async put<T>(path: string, data?: unknown): Promise<T> {
-    const response = await apiClient.put<ApiResponse<T>>(this.getFullPath(path), data);
-    return response.data.data;
+    const response = await apiClient.put<ApiResponse<T>>(
+        this.getFullPath(path),
+        data,
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -62,8 +83,14 @@ export abstract class BaseService {
    * @param params - 查询参数
    * @returns 响应数据
    */
-  protected static async delete<T>(path: string, params?: Record<string, unknown>): Promise<T> {
-    const response = await apiClient.delete<ApiResponse<T>>(this.getFullPath(path), {params});
-    return response.data.data;
+  protected static async delete<T>(
+      path: string,
+      params?: Record<string, unknown>,
+  ): Promise<T> {
+    const response = await apiClient.delete<ApiResponse<T>>(
+        this.getFullPath(path),
+        {params},
+    );
+    return this.unwrapApiResponse(response);
   }
 }

--- a/frontend/lib/services/core/types.ts
+++ b/frontend/lib/services/core/types.ts
@@ -26,6 +26,8 @@ export interface PaginatedResponse<T = unknown> {
 export interface ApiError {
   /** 错误信息 */
   error_msg: string;
+  /** 请求ID */
+  request_id?: string;
 }
 
 /**

--- a/frontend/lib/services/dashboard/dashboard.service.ts
+++ b/frontend/lib/services/dashboard/dashboard.service.ts
@@ -38,12 +38,7 @@ export class DashboardService extends BaseService {
           params: {days: Math.max(1, Math.min(30, days))},
         },
     );
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return this.normalizeData(response.data.data);
+    return this.normalizeData(this.unwrapApiResponse(response));
   }
 
   /**
@@ -63,7 +58,8 @@ export class DashboardService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取仪表盘数据失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取仪表盘数据失败';
       return {
         success: false,
         data: this.getDefaultData(),
@@ -93,12 +89,30 @@ export class DashboardService extends BaseService {
 
     // 解析各个JSON字段
     const userGrowth = parseJsonField<UserGrowthData[]>(rawData.userGrowth, []);
-    const activityData = parseJsonField<ActivityData[]>(rawData.activityData, []);
-    const projectTags = parseJsonField<ProjectTagsData[]>(rawData.projectTags, []);
-    const distributeModes = parseJsonField<DistributeModeData[]>(rawData.distributeModes, []);
-    const hotProjects = parseJsonField<HotProjectData[]>(rawData.hotProjects, []);
-    const activeCreators = parseJsonField<RawActiveCreatorData[]>(rawData.activeCreators, []);
-    const activeReceivers = parseJsonField<RawActiveReceiverData[]>(rawData.activeReceivers, []);
+    const activityData = parseJsonField<ActivityData[]>(
+        rawData.activityData,
+        [],
+    );
+    const projectTags = parseJsonField<ProjectTagsData[]>(
+        rawData.projectTags,
+        [],
+    );
+    const distributeModes = parseJsonField<DistributeModeData[]>(
+        rawData.distributeModes,
+        [],
+    );
+    const hotProjects = parseJsonField<HotProjectData[]>(
+        rawData.hotProjects,
+        [],
+    );
+    const activeCreators = parseJsonField<RawActiveCreatorData[]>(
+        rawData.activeCreators,
+        [],
+    );
+    const activeReceivers = parseJsonField<RawActiveReceiverData[]>(
+        rawData.activeReceivers,
+        [],
+    );
     const summary = parseJsonField<StatsSummary>(rawData.summary, {
       totalUsers: 0,
       newUsers: 0,
@@ -108,25 +122,31 @@ export class DashboardService extends BaseService {
     });
 
     // 处理热门项目数据，转换tags数组为单个tag字符串用于显示
-    const normalizedHotProjects: HotProjectData[] = hotProjects.map((project) => ({
-      name: project.name,
-      tags: Array.isArray(project.tags) ? project.tags : [], // 保持原始tags数组
-      receiveCount: project.receiveCount,
-    }));
+    const normalizedHotProjects: HotProjectData[] = hotProjects.map(
+        (project) => ({
+          name: project.name,
+          tags: Array.isArray(project.tags) ? project.tags : [], // 保持原始tags数组
+          receiveCount: project.receiveCount,
+        }),
+    );
 
     // 处理活跃创建者数据，转换nickname或username为name
-    const normalizedActiveCreators: ActiveCreatorData[] = activeCreators.map((activeCreator) => ({
-      avatar: activeCreator.avatar,
-      name: activeCreator.nickname || activeCreator.username,
-      projectCount: activeCreator.projectCount,
-    }));
+    const normalizedActiveCreators: ActiveCreatorData[] = activeCreators.map(
+        (activeCreator) => ({
+          avatar: activeCreator.avatar,
+          name: activeCreator.nickname || activeCreator.username,
+          projectCount: activeCreator.projectCount,
+        }),
+    );
 
     // 处理活跃领取者数据，转换nickname或username为name
-    const normalizedActiveReceivers: ActiveReceiverData[] = activeReceivers.map((activeReceiver) => ({
-      avatar: activeReceiver.avatar,
-      name: activeReceiver.nickname || activeReceiver.username,
-      receiveCount: activeReceiver.receiveCount,
-    }));
+    const normalizedActiveReceivers: ActiveReceiverData[] = activeReceivers.map(
+        (activeReceiver) => ({
+          avatar: activeReceiver.avatar,
+          name: activeReceiver.nickname || activeReceiver.username,
+          receiveCount: activeReceiver.receiveCount,
+        }),
+    );
 
     return {
       userGrowth,

--- a/frontend/lib/services/project/project.service.ts
+++ b/frontend/lib/services/project/project.service.ts
@@ -42,12 +42,10 @@ export class ProjectService extends BaseService {
    * @returns 项目详细信息
    */
   static async getProject(projectId: string): Promise<GetProjectResponseData> {
-    const response = await apiClient.get<GetProjectResponse>(`${this.basePath}/${projectId}`);
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return response.data.data;
+    const response = await apiClient.get<GetProjectResponse>(
+        `${this.basePath}/${projectId}`,
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -55,12 +53,14 @@ export class ProjectService extends BaseService {
    * @param projectData - 项目创建数据
    * @returns 创建结果，包含项目ID
    */
-  static async createProject(projectData: CreateProjectRequest): Promise<CreateProjectResponseData> {
-    const response = await apiClient.post<CreateProjectResponse>(`${this.basePath}`, projectData);
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-    return response.data.data;
+  static async createProject(
+      projectData: CreateProjectRequest,
+  ): Promise<CreateProjectResponseData> {
+    const response = await apiClient.post<CreateProjectResponse>(
+        `${this.basePath}`,
+        projectData,
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -73,10 +73,11 @@ export class ProjectService extends BaseService {
       projectId: string,
       projectData: UpdateProjectRequest,
   ): Promise<void> {
-    const response = await apiClient.put<ProjectResponse>(`${this.basePath}/${projectId}`, projectData);
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
+    const response = await apiClient.put<ProjectResponse>(
+        `${this.basePath}/${projectId}`,
+        projectData,
+    );
+    this.unwrapApiResponse(response);
   }
 
   /**
@@ -85,10 +86,10 @@ export class ProjectService extends BaseService {
    * @returns 删除结果
    */
   static async deleteProject(projectId: string): Promise<void> {
-    const response = await apiClient.delete<ProjectResponse>(`${this.basePath}/${projectId}`);
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
+    const response = await apiClient.delete<ProjectResponse>(
+        `${this.basePath}/${projectId}`,
+    );
+    this.unwrapApiResponse(response);
   }
 
   /**
@@ -105,18 +106,17 @@ export class ProjectService extends BaseService {
       size: number = 10,
       search: string = '',
   ): Promise<ProjectReceiver[]> {
-    const response = await apiClient.get<ProjectReceiversResponse>(`${this.basePath}/${projectId}/receivers`, {
-      params: {
-        current,
-        size,
-        search,
-      },
-    });
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-    // 处理后端返回null的情况，确保返回空数组而不是null
-    return response.data.data || [];
+    const response = await apiClient.get<ProjectReceiversResponse>(
+        `${this.basePath}/${projectId}/receivers`,
+        {
+          params: {
+            current,
+            size,
+            search,
+          },
+        },
+    );
+    return this.unwrapApiResponse(response) || [];
   }
 
   /**
@@ -125,17 +125,17 @@ export class ProjectService extends BaseService {
    * @param captchaToken - hCaptcha验证令牌
    * @returns 领取结果，包含领取内容
    */
-  static async receiveProject(projectId: string, captchaToken: string): Promise<ReceiveProjectData> {
+  static async receiveProject(
+      projectId: string,
+      captchaToken: string,
+  ): Promise<ReceiveProjectData> {
     const response = await apiClient.post<ReceiveProjectResponse>(
         `${this.basePath}/${projectId}/receive`,
         {
           captcha_token: captchaToken,
         },
     );
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-    return response.data.data;
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -143,20 +143,20 @@ export class ProjectService extends BaseService {
    * @param params - 分页参数
    * @returns 领取历史数据
    */
-  static async getReceiveHistory(params: ReceiveHistoryRequest): Promise<ReceiveHistoryData> {
-    const response = await apiClient.get<ReceiveHistoryResponse>(`${this.basePath}/received`, {
-      params: {
-        current: params.current,
-        size: params.size,
-        search: params.search || '',
-      },
-    });
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return response.data.data;
+  static async getReceiveHistory(
+      params: ReceiveHistoryRequest,
+  ): Promise<ReceiveHistoryData> {
+    const response = await apiClient.get<ReceiveHistoryResponse>(
+        `${this.basePath}/received`,
+        {
+          params: {
+            current: params.current,
+            size: params.size,
+            search: params.search || '',
+          },
+        },
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -164,18 +164,18 @@ export class ProjectService extends BaseService {
    * @param params - 图表参数
    * @returns 领取历史图表数据
    */
-  static async getReceiveHistoryChart(params: ReceiveHistoryChartRequest): Promise<ReceiveHistoryChartPoint[]> {
-    const response = await apiClient.get<ReceiveHistoryChartResponse>(`${this.basePath}/received/chart`, {
-      params: {
-        day: params.day,
-      },
-    });
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return response.data.data || [];
+  static async getReceiveHistoryChart(
+      params: ReceiveHistoryChartRequest,
+  ): Promise<ReceiveHistoryChartPoint[]> {
+    const response = await apiClient.get<ReceiveHistoryChartResponse>(
+        `${this.basePath}/received/chart`,
+        {
+          params: {
+            day: params.day,
+          },
+        },
+    );
+    return this.unwrapApiResponse(response) || [];
   }
 
   /**
@@ -185,12 +185,7 @@ export class ProjectService extends BaseService {
   static async getTags(): Promise<string[]> {
     try {
       const response = await apiClient.get<TagsResponse>('/api/v1/tags');
-
-      if (response.data.error_msg) {
-        throw new Error(response.data.error_msg);
-      }
-
-      return response.data.data || [];
+      return this.unwrapApiResponse(response) || [];
     } catch (error) {
       console.warn('获取标签列表失败:', error);
       return [];
@@ -202,7 +197,9 @@ export class ProjectService extends BaseService {
    * @param params - 分页和过滤参数
    * @returns 项目列表数据
    */
-  static async getProjects(params: ListProjectsRequest): Promise<ProjectListData> {
+  static async getProjects(
+      params: ListProjectsRequest,
+  ): Promise<ProjectListData> {
     const requestParams: ApiRequestParams = {
       current: params.current,
       size: params.size,
@@ -212,18 +209,16 @@ export class ProjectService extends BaseService {
       requestParams.tags = params.tags;
     }
 
-    const response = await apiClient.get<ProjectListResponse>(`${this.basePath}`, {
-      params: requestParams,
-      paramsSerializer: {
-        indexes: null,
-      },
-    });
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return response.data.data;
+    const response = await apiClient.get<ProjectListResponse>(
+        `${this.basePath}`,
+        {
+          params: requestParams,
+          paramsSerializer: {
+            indexes: null,
+          },
+        },
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -231,7 +226,9 @@ export class ProjectService extends BaseService {
    * @param params - 分页和过滤参数
    * @returns 我的项目列表数据
    */
-  static async getMyProjects(params: ListProjectsRequest): Promise<ProjectListData> {
+  static async getMyProjects(
+      params: ListProjectsRequest,
+  ): Promise<ProjectListData> {
     const requestParams: ApiRequestParams = {
       current: params.current,
       size: params.size,
@@ -241,18 +238,16 @@ export class ProjectService extends BaseService {
       requestParams.tags = params.tags;
     }
 
-    const response = await apiClient.get<ProjectListResponse>(`${this.basePath}/mine`, {
-      params: requestParams,
-      paramsSerializer: {
-        indexes: null,
-      },
-    });
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
-
-    return response.data.data;
+    const response = await apiClient.get<ProjectListResponse>(
+        `${this.basePath}/mine`,
+        {
+          params: requestParams,
+          paramsSerializer: {
+            indexes: null,
+          },
+        },
+    );
+    return this.unwrapApiResponse(response);
   }
 
   /**
@@ -262,13 +257,13 @@ export class ProjectService extends BaseService {
    * @returns 举报结果
    */
   static async reportProject(projectId: string, reason: string): Promise<void> {
-    const response = await apiClient.post<ReportProjectResponse>(`${this.basePath}/${projectId}/report`, {
-      reason,
-    });
-
-    if (response.data.error_msg) {
-      throw new Error(response.data.error_msg);
-    }
+    const response = await apiClient.post<ReportProjectResponse>(
+        `${this.basePath}/${projectId}/report`,
+        {
+          reason,
+        },
+    );
+    this.unwrapApiResponse(response);
   }
 
   /**
@@ -288,7 +283,8 @@ export class ProjectService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取项目详情失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取项目详情失败';
       return {
         success: false,
         error: errorMessage,
@@ -310,7 +306,8 @@ export class ProjectService extends BaseService {
       const data = await this.createProject(projectData);
       return {success: true, data};
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '创建项目失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '创建项目失败';
       return {
         success: false,
         error: errorMessage,
@@ -335,7 +332,8 @@ export class ProjectService extends BaseService {
       await this.updateProject(projectId, projectData);
       return {success: true};
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '更新项目失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '更新项目失败';
       return {
         success: false,
         error: errorMessage,
@@ -356,7 +354,8 @@ export class ProjectService extends BaseService {
       await this.deleteProject(projectId);
       return {success: true};
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '删除项目失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '删除项目失败';
       return {
         success: false,
         error: errorMessage,
@@ -370,7 +369,10 @@ export class ProjectService extends BaseService {
    * @param captchaToken - hCaptcha验证令牌
    * @returns 领取结果，包含成功状态、领取内容和错误信息
    */
-  static async receiveProjectSafe(projectId: string, captchaToken: string): Promise<{
+  static async receiveProjectSafe(
+      projectId: string,
+      captchaToken: string,
+  ): Promise<{
     success: boolean;
     data?: ReceiveProjectData;
     error?: string;
@@ -379,7 +381,8 @@ export class ProjectService extends BaseService {
       const data = await this.receiveProject(projectId, captchaToken);
       return {success: true, data};
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '领取项目内容失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '领取项目内容失败';
       return {
         success: false,
         error: errorMessage,
@@ -404,7 +407,8 @@ export class ProjectService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取领取历史失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取领取历史失败';
       return {
         success: false,
         data: {total: 0, results: []},
@@ -418,7 +422,9 @@ export class ProjectService extends BaseService {
    * @param params - 图表参数
    * @returns 领取历史图表结果，包含成功状态、数据和错误信息
    */
-  static async getReceiveHistoryChartSafe(params: ReceiveHistoryChartRequest): Promise<{
+  static async getReceiveHistoryChartSafe(
+      params: ReceiveHistoryChartRequest,
+  ): Promise<{
     success: boolean;
     data?: ReceiveHistoryChartPoint[];
     error?: string;
@@ -430,7 +436,8 @@ export class ProjectService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取领取历史图表失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取领取历史图表失败';
       return {
         success: false,
         data: [],
@@ -455,7 +462,8 @@ export class ProjectService extends BaseService {
         tags,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取标签失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取标签失败';
       return {
         success: false,
         tags: [],
@@ -481,7 +489,8 @@ export class ProjectService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取项目列表失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取项目列表失败';
       return {
         success: false,
         data: {total: 0, results: []},
@@ -507,7 +516,8 @@ export class ProjectService extends BaseService {
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取我的项目列表失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取我的项目列表失败';
       return {
         success: false,
         data: {total: 0, results: []},
@@ -522,7 +532,10 @@ export class ProjectService extends BaseService {
    * @param reason - 举报理由
    * @returns 举报结果，包含成功状态和错误信息
    */
-  static async reportProjectSafe(projectId: string, reason: string): Promise<{
+  static async reportProjectSafe(
+      projectId: string,
+      reason: string,
+  ): Promise<{
     success: boolean;
     error?: string;
   }> {
@@ -557,13 +570,19 @@ export class ProjectService extends BaseService {
     error?: string;
   }> {
     try {
-      const data = await this.getProjectReceivers(projectId, current, size, search);
+      const data = await this.getProjectReceivers(
+          projectId,
+          current,
+          size,
+          search,
+      );
       return {
         success: true,
         data,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '获取项目领取者列表失败';
+      const errorMessage =
+        error instanceof Error ? error.message : '获取项目领取者列表失败';
       return {
         success: false,
         data: [],

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -54,22 +54,38 @@ func init() {
 	logger.Level()
 }
 
+func Debug(ctx context.Context, msg string, fields ...zap.Field) {
+	logger.Ctx(ctx).Debug(msg, append(fields, getContextFields(ctx)...)...)
+}
+
 func DebugF(ctx context.Context, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	logger.Ctx(ctx).Debug(msg, getTraceIDFields(ctx)...)
+	Debug(ctx, msg)
+}
+
+func Info(ctx context.Context, msg string, fields ...zap.Field) {
+	logger.Ctx(ctx).Info(msg, append(fields, getContextFields(ctx)...)...)
 }
 
 func InfoF(ctx context.Context, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	logger.Ctx(ctx).Info(msg, getTraceIDFields(ctx)...)
+	Info(ctx, msg)
+}
+
+func Warn(ctx context.Context, msg string, fields ...zap.Field) {
+	logger.Ctx(ctx).Warn(msg, append(fields, getContextFields(ctx)...)...)
 }
 
 func WarnF(ctx context.Context, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	logger.Ctx(ctx).Warn(msg, getTraceIDFields(ctx)...)
+	Warn(ctx, msg)
+}
+
+func Error(ctx context.Context, msg string, fields ...zap.Field) {
+	logger.Ctx(ctx).Error(msg, append(fields, getContextFields(ctx)...)...)
 }
 
 func ErrorF(ctx context.Context, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	logger.Ctx(ctx).Error(msg, getTraceIDFields(ctx)...)
+	Error(ctx, msg)
 }

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 
 	"github.com/linux-do/cdk/internal/config"
+	"github.com/linux-do/cdk/internal/requestid"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -122,11 +123,23 @@ func getLogLevel() zapcore.Level {
 	}
 }
 
-func getTraceIDFields(ctx context.Context) []zap.Field {
+func getContextFields(ctx context.Context) []zap.Field {
+	fields := make([]zap.Field, 0, 3)
+
+	if requestID := requestid.FromContext(ctx); requestID != "" {
+		fields = append(fields, zap.String("request_id", requestID))
+	}
+
 	span := trace.SpanFromContext(ctx)
 	spanContext := span.SpanContext()
-	return []zap.Field{
-		zap.String("traceID", spanContext.TraceID().String()),
-		zap.String("spanID", spanContext.SpanID().String()),
+
+	if spanContext.HasTraceID() {
+		fields = append(fields, zap.String("trace_id", spanContext.TraceID().String()))
 	}
+
+	if spanContext.HasSpanID() {
+		fields = append(fields, zap.String("span_id", spanContext.SpanID().String()))
+	}
+
+	return fields
 }

--- a/internal/logger/utils_test.go
+++ b/internal/logger/utils_test.go
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 linux.do
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package logger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/linux-do/cdk/internal/requestid"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestGetContextFields(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to parse trace id: %v", err)
+	}
+
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("failed to parse span id: %v", err)
+	}
+
+	ctx := requestid.WithContext(context.Background(), "req_test")
+	ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	}))
+
+	fields := getContextFields(ctx)
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(fields))
+	}
+
+	got := map[string]string{}
+	for _, field := range fields {
+		got[field.Key] = field.String
+	}
+
+	if got["request_id"] != "req_test" {
+		t.Fatalf("expected request_id field, got %#v", got)
+	}
+	if got["trace_id"] != traceID.String() {
+		t.Fatalf("expected trace_id field, got %#v", got)
+	}
+	if got["span_id"] != spanID.String() {
+		t.Fatalf("expected span_id field, got %#v", got)
+	}
+}

--- a/internal/requestid/requestid.go
+++ b/internal/requestid/requestid.go
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 linux.do
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package requestid
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const HeaderName = "X-Request-Id"
+
+type contextKey string
+
+const requestIDContextKey contextKey = "request_id"
+
+func New() string {
+	return "req_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+func Normalize(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func GetOrNew(value string) string {
+	requestID := Normalize(value)
+	if requestID != "" {
+		return requestID
+	}
+
+	return New()
+}
+
+func WithContext(ctx context.Context, requestID string) context.Context {
+	normalized := Normalize(requestID)
+	if normalized == "" {
+		return ctx
+	}
+
+	return context.WithValue(ctx, requestIDContextKey, normalized)
+}
+
+func FromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	requestID, ok := ctx.Value(requestIDContextKey).(string)
+	if !ok {
+		return ""
+	}
+
+	return Normalize(requestID)
+}

--- a/internal/requestid/requestid_test.go
+++ b/internal/requestid/requestid_test.go
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 linux.do
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package requestid
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetOrNew(t *testing.T) {
+	t.Run("uses existing request id", func(t *testing.T) {
+		requestID := GetOrNew("  req_existing  ")
+		if requestID != "req_existing" {
+			t.Fatalf("expected normalized request id, got %q", requestID)
+		}
+	})
+
+	t.Run("generates request id when empty", func(t *testing.T) {
+		requestID := GetOrNew("")
+		if requestID == "" {
+			t.Fatal("expected generated request id")
+		}
+		if len(requestID) <= len("req_") || requestID[:4] != "req_" {
+			t.Fatalf("expected generated request id with prefix, got %q", requestID)
+		}
+	})
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ctx := WithContext(context.Background(), " req_test ")
+
+	requestID := FromContext(ctx)
+	if requestID != "req_test" {
+		t.Fatalf("expected request id to round trip, got %q", requestID)
+	}
+
+	if got := FromContext(context.Background()); got != "" {
+		t.Fatalf("expected empty request id for bare context, got %q", got)
+	}
+}

--- a/internal/router/middlewares.go
+++ b/internal/router/middlewares.go
@@ -25,56 +25,61 @@
 package router
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/linux-do/cdk/internal/logger"
-	"github.com/linux-do/cdk/internal/otel_trace"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	"strconv"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/linux-do/cdk/internal/logger"
+	"github.com/linux-do/cdk/internal/requestid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
+
+func requestIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := requestid.GetOrNew(c.GetHeader(requestid.HeaderName))
+		ctx := requestid.WithContext(c.Request.Context(), requestID)
+
+		c.Request = c.Request.WithContext(ctx)
+		c.Writer.Header().Set(requestid.HeaderName, requestID)
+		c.Next()
+	}
+}
 
 func loggerMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// 初始化 Trace
-		ctx, span := otel_trace.Start(c.Request.Context(), "LoggerMiddleware")
-		defer span.End()
-
-		// 开始计时
+		ctx := c.Request.Context()
+		span := trace.SpanFromContext(ctx)
 		start := time.Now()
 
-		// 记录请求路径和 Query
-		path := c.Request.URL.Path
-		raw := c.Request.URL.RawQuery
-		if raw != "" {
-			path = path + "?" + raw
-		}
-
-		// 执行请求
 		c.Next()
 
-		// 停止计时
-		end := time.Now()
-		latency := end.Sub(start)
+		status := c.Writer.Status()
+		latency := time.Since(start)
+		fields := []zap.Field{
+			zap.String("method", c.Request.Method),
+			zap.String("path", c.Request.URL.Path),
+			zap.Int("status", status),
+			zap.Int64("latency_ms", latency.Milliseconds()),
+			zap.String("client_ip", c.ClientIP()),
+			zap.Int("response_size", c.Writer.Size()),
+		}
+		if rawQuery := c.Request.URL.RawQuery; rawQuery != "" {
+			fields = append(fields, zap.String("query", rawQuery))
+		}
 
-		// 打印日志
-		logger.InfoF(
-			ctx,
-			"[LoggerMiddleware] %s %s\nStartTime: %s\nEndTime: %s\nLatency: %d\nClientIP: %s\nResponse: %d %d",
-			c.Request.Method,
-			path,
-			start.Format(time.RFC3339),
-			end.Format(time.RFC3339),
-			latency.Milliseconds(),
-			c.ClientIP(),
-			c.Writer.Status(),
-			c.Writer.Size(),
-		)
+		logger.Info(ctx, "http request completed", fields...)
 
-		// 设置 Span 状态
-		if c.Writer.Status() >= 400 {
-			span := trace.SpanFromContext(ctx)
-			span.SetStatus(codes.Error, strconv.Itoa(c.Writer.Status()))
+		if span.SpanContext().IsValid() {
+			if requestID := requestid.FromContext(ctx); requestID != "" {
+				span.SetAttributes(attribute.String("request.id", requestID))
+			}
+		}
+
+		if status >= 400 {
+			span.SetStatus(codes.Error, strconv.Itoa(status))
 		}
 	}
 }

--- a/internal/router/middlewares_test.go
+++ b/internal/router/middlewares_test.go
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 linux.do
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/linux-do/cdk/internal/requestid"
+)
+
+func TestRequestIDMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("generates request id when missing", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/health", nil)
+
+		requestIDMiddleware()(ctx)
+
+		requestID := recorder.Header().Get(requestid.HeaderName)
+		if requestID == "" {
+			t.Fatal("expected response header to include request id")
+		}
+
+		if got := requestid.FromContext(ctx.Request.Context()); got != requestID {
+			t.Fatalf("expected request id in context to match response header, got %q", got)
+		}
+	})
+
+	t.Run("reuses incoming request id", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/health", nil)
+		ctx.Request.Header.Set(requestid.HeaderName, "req_existing")
+
+		requestIDMiddleware()(ctx)
+
+		requestID := recorder.Header().Get(requestid.HeaderName)
+		if requestID != "req_existing" {
+			t.Fatalf("expected existing request id to be reused, got %q", requestID)
+		}
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -83,7 +83,7 @@ func Serve() {
 	r.Use(sessions.Sessions(config.Config.App.SessionCookieName, sessionStore))
 
 	// 补充中间件
-	r.Use(otelgin.Middleware(config.Config.App.AppName), loggerMiddleware())
+	r.Use(requestIDMiddleware(), otelgin.Middleware(config.Config.App.AppName), loggerMiddleware())
 
 	apiGroup := r.Group(config.Config.App.APIPrefix)
 	{

--- a/internal/task/worker/middlewares.go
+++ b/internal/task/worker/middlewares.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
 
 // taskLoggingMiddleware 记录任务日志中间件
@@ -60,30 +61,31 @@ func taskLoggingMiddleware(h asynq.Handler) asynq.Handler {
 		latency := time.Since(start)
 
 		if err != nil {
-			// 处理出错，记录错误日志
-			logger.ErrorF(
+			logger.Error(
 				ctx,
-				"[TaskMiddleware] 任务处理失败 Type: %s\nStartTime: %s\nLatency: %d ms\nError: %v",
-				t.Type(),
-				start.Format(time.RFC3339),
-				latency.Milliseconds(),
-				err,
+				"task processing failed",
+				zap.String("task_type", t.Type()),
+				zap.String("task_id", t.ResultWriter().TaskID()),
+				zap.Int("payload_size", len(t.Payload())),
+				zap.String("start_time", start.Format(time.RFC3339)),
+				zap.Int64("latency_ms", latency.Milliseconds()),
+				zap.Error(err),
 			)
 
-			// 设置 Span 错误状态
 			span.SetStatus(codes.Error, err.Error())
 			span.RecordError(err)
 			return err
 		}
 
-		// 处理成功，记录成功日志
-		logger.InfoF(
+		logger.Info(
 			ctx,
-			"[TaskMiddleware] 任务处理完成 Type: %s\nStartTime: %s\nEndTime: %s\nLatency: %d ms",
-			t.Type(),
-			start.Format(time.RFC3339),
-			time.Now().Format(time.RFC3339),
-			latency.Milliseconds(),
+			"task processing completed",
+			zap.String("task_type", t.Type()),
+			zap.String("task_id", t.ResultWriter().TaskID()),
+			zap.Int("payload_size", len(t.Payload())),
+			zap.String("start_time", start.Format(time.RFC3339)),
+			zap.String("end_time", time.Now().Format(time.RFC3339)),
+			zap.Int64("latency_ms", latency.Milliseconds()),
 		)
 
 		return nil


### PR DESCRIPTION
**例行检查**

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/cdk/blob/master/CODE_OF_CONDUCT.md)，
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/cdk/blob/master/CLA.md)，确认我的贡献将根据项目的 MIT 许可证进行许可，
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并，

**关联信息**

无。

**变更内容**

这次改动主要补了一条更完整的排障链路，把 `request_id` 从后端请求处理一路带到日志和前端报错里。

- 后端新增 request id middleware，生成或透传 `X-Request-Id`
- request id 会写入 request context，并回写到响应头
- logger 自动补充 `request_id`、`trace_id`、`span_id`
- HTTP access log 改成结构化字段输出
- worker 日志也改成结构化输出，保留任务类型、任务 id、耗时等信息
- 前端新增统一的 `ApiClientError`
- 前端会从响应头提取 `x-request-id`，并拼进用户可见的错误信息
- 服务层统一走 response unwrap，避免每个 service 各自手写错误判断

**变更原因**

之前后端虽然已经有 tracing，但一次请求真正落到日志里时，HTTP access log 还是一整段拼接字符串，前端报错也只会显示普通文案。用户反馈“创建失败了”这类问题时，能知道失败了，但不太容易顺着把整条链路查出来。

这次补上 `request_id` 之后，至少在失败场景里，用户给一个 request id，就能更快定位到对应的后端请求日志。

## Before / After

### 1. HTTP 日志

Before

```json
{
  "time": "2026-04-17T14:00:01+08:00",
  "level": "info",
  "caller": "router/middlewares.go:61",
  "msg": "[LoggerMiddleware] POST /api/v1/projects\nStartTime: 2026-04-17T14:00:01+08:00\nEndTime: 2026-04-17T14:00:01+08:00\nLatency: 123\nClientIP: 127.0.0.1\nResponse: 500 68",
  "traceID": "9c4d2b4c7c0d2d65d14b7f4f4a9db5b1",
  "spanID": "f0a12c8de91d45aa"
}
```

After

```json
{
  "time": "2026-04-17T14:00:01+08:00",
  "level": "info",
  "caller": "router/middlewares.go:73",
  "msg": "http request completed",
  "request_id": "req_7fd3d8c1b0b7451e8a9d1f24a4f5f233",
  "trace_id": "9c4d2b4c7c0d2d65d14b7f4f4a9db5b1",
  "span_id": "f0a12c8de91d45aa",
  "method": "POST",
  "path": "/api/v1/projects",
  "status": 500,
  "latency_ms": 123,
  "client_ip": "127.0.0.1",
  "response_size": 68
}
```

### 2. Worker 日志

Before

```json
{
  "level": "error",
  "msg": "[TaskMiddleware] 任务处理失败 Type: UpdateUserBadgeScores\nStartTime: 2026-04-17T14:05:00+08:00\nLatency: 85 ms\nError: some error",
  "traceID": "a6e86d9b2d5f4c0b8a98b0fa3bce8d91",
  "spanID": "6a72b6a51f8bd44e"
}
```

After

```json
{
  "level": "error",
  "msg": "task processing failed",
  "trace_id": "a6e86d9b2d5f4c0b8a98b0fa3bce8d91",
  "span_id": "6a72b6a51f8bd44e",
  "task_type": "UpdateUserBadgeScores",
  "task_id": "c9d8cfd3b7d24f2f",
  "payload_size": 512,
  "start_time": "2026-04-17T14:05:00+08:00",
  "latency_ms": 85,
  "error": "some error"
}
```

### 3. 前端报错

Before

```http
HTTP/1.1 500 Internal Server Error
Content-Type: application/json

{"error_msg":"创建项目失败","data":null}
```

前端只会看到：

```text
创建项目失败
```

After

```http
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
X-Request-Id: req_7fd3d8c1b0b7451e8a9d1f24a4f5f233

{"error_msg":"创建项目失败","data":null}
```

前端会看到：

```text
创建项目失败 (Request ID: req_7fd3d8c1b0b7451e8a9d1f24a4f5f233)
```

改动意义：线上报错时会很直接，不用再只拿着一句“创建失败”去翻时间段。

## 验证

本地已完成这些检查：

- `gofmt` 已跑过
- `go test ./internal/requestid` 通过
- `go test ./internal/logger` 通过
- `go test ./internal/router -run TestRequestIDMiddleware` 通过
- `go test ./internal/requestid ./internal/logger ./internal/router ./internal/task/worker` 通过
- 前端 `eslint` 通过
- 前端 `tsc --noEmit` 通过
