### PR TITLE
fix: reset project completed status when order expires or refunds

### DIFF
--- a/internal/apps/payment/service.go
+++ b/internal/apps/payment/service.go
@@ -323,8 +323,10 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 				return false, "update order status failed"
 			}
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
-			// 退款重试成功后检查并重置项目完成状态
-			resetProjectCompletedStatusAfterRefund(ctx, order.ProjectID)
+			var proj project.Project
+			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
+				proj.ResetCompletedStatusIfHasStock(ctx)
+			}
 			return true, "refund retry ok"
 		}
 		return false, "refund retry failed"
@@ -363,8 +365,10 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 			updates["refunded_at"] = &tNow
 			// 把 item 推回 Redis 队列恢复库存
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
-			// 退款成功后检查并重置项目完成状态
-			resetProjectCompletedStatusAfterRefund(ctx, order.ProjectID)
+			var proj project.Project
+			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
+				proj.ResetCompletedStatusIfHasStock(ctx)
+			}
 		} else {
 			updates["status"] = OrderStatusRefunding
 		}
@@ -398,39 +402,6 @@ func fulfillPaidOrder(ctx context.Context, order *PaymentOrder) error {
 // CallbackURLs 返回当前平台配置的回调地址,用于前端展示给用户。
 func CallbackURLs() (notifyURL, returnURL string) {
 	return callbackNotifyURL(), callbackReturnURL("")
-}
-
-// resetProjectCompletedStatusAfterRefund 退款后检查并重置项目的已完成状态
-// 这个函数复用了 tasks.go 中的逻辑，当退款成功归还 item 后调用
-func resetProjectCompletedStatusAfterRefund(ctx context.Context, projectID string) {
-	var proj project.Project
-	if err := db.DB(ctx).Where("id = ?", projectID).First(&proj).Error; err != nil {
-		logger.ErrorF(ctx, "payment refund: failed to load project %s: %v", projectID, err)
-		return
-	}
-
-	// 只处理已标记为完成的项目
-	if !proj.IsCompleted {
-		return
-	}
-
-	// 检查 Redis 是否有库存
-	hasStock, err := proj.HasStock(ctx)
-	if err != nil {
-		logger.ErrorF(ctx, "payment refund: failed to check stock for project %s: %v", projectID, err)
-		return
-	}
-
-	// 如果有库存但项目标记为已完成，则重置
-	if hasStock {
-		if err := db.DB(ctx).Model(&project.Project{}).
-			Where("id = ? AND is_completed = ?", projectID, true).
-			Update("is_completed", false).Error; err != nil {
-			logger.ErrorF(ctx, "payment refund: failed to reset completed status for project %s: %v", projectID, err)
-		} else {
-			logger.InfoF(ctx, "payment refund: reset project %s completed status (has stock after refund)", projectID)
-		}
-	}
 }
 
 // ErrOrderNotFoundSentinel 外部判断

--- a/internal/apps/payment/service.go
+++ b/internal/apps/payment/service.go
@@ -323,6 +323,8 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 				return false, "update order status failed"
 			}
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
+			// 退款重试成功后检查并重置项目完成状态
+			resetProjectCompletedStatusAfterRefund(ctx, order.ProjectID)
 			return true, "refund retry ok"
 		}
 		return false, "refund retry failed"
@@ -361,6 +363,8 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 			updates["refunded_at"] = &tNow
 			// 把 item 推回 Redis 队列恢复库存
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
+			// 退款成功后检查并重置项目完成状态
+			resetProjectCompletedStatusAfterRefund(ctx, order.ProjectID)
 		} else {
 			updates["status"] = OrderStatusRefunding
 		}
@@ -394,6 +398,39 @@ func fulfillPaidOrder(ctx context.Context, order *PaymentOrder) error {
 // CallbackURLs 返回当前平台配置的回调地址,用于前端展示给用户。
 func CallbackURLs() (notifyURL, returnURL string) {
 	return callbackNotifyURL(), callbackReturnURL("")
+}
+
+// resetProjectCompletedStatusAfterRefund 退款后检查并重置项目的已完成状态
+// 这个函数复用了 tasks.go 中的逻辑，当退款成功归还 item 后调用
+func resetProjectCompletedStatusAfterRefund(ctx context.Context, projectID string) {
+	var proj project.Project
+	if err := db.DB(ctx).Where("id = ?", projectID).First(&proj).Error; err != nil {
+		logger.ErrorF(ctx, "payment refund: failed to load project %s: %v", projectID, err)
+		return
+	}
+
+	// 只处理已标记为完成的项目
+	if !proj.IsCompleted {
+		return
+	}
+
+	// 检查 Redis 是否有库存
+	hasStock, err := proj.HasStock(ctx)
+	if err != nil {
+		logger.ErrorF(ctx, "payment refund: failed to check stock for project %s: %v", projectID, err)
+		return
+	}
+
+	// 如果有库存但项目标记为已完成，则重置
+	if hasStock {
+		if err := db.DB(ctx).Model(&project.Project{}).
+			Where("id = ? AND is_completed = ?", projectID, true).
+			Update("is_completed", false).Error; err != nil {
+			logger.ErrorF(ctx, "payment refund: failed to reset completed status for project %s: %v", projectID, err)
+		} else {
+			logger.InfoF(ctx, "payment refund: reset project %s completed status (has stock after refund)", projectID)
+		}
+	}
 }
 
 // ErrOrderNotFoundSentinel 外部判断

--- a/internal/apps/payment/service.go
+++ b/internal/apps/payment/service.go
@@ -204,7 +204,7 @@ func InitiatePayment(ctx context.Context, p *project.Project, payer *oauth.User,
 			return err
 		}
 		itemID = reservedItemID
-		logger.InfoF(ctx, "Reserved item %d for project %d and payer %d", itemID, p.ID, payer.ID)
+		logger.InfoF(ctx, "Reserved item %d for project %s and payer %d", itemID, p.ID, payer.ID)
 
 		outTradeNo := genOutTradeNo()
 		order := PaymentOrder{
@@ -315,19 +315,13 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 		refundErr := doEpayRefund(ctx, cfg.ClientID, secret, order.TradeNo, moneyString(order.Amount))
 		if refundErr == nil {
 			tNow := time.Now()
-			if updateErr := db.DB(ctx).
-				Model(&PaymentOrder{}).
-				Where("out_trade_no = ?", outTradeNo).
-				Updates(map[string]any{"status": OrderStatusRefunded, "refunded_at": &tNow}).
-				Error; updateErr != nil {
+			processed, updateErr := markOrderRefundedAndReturnItem(ctx, &order, map[string]any{"status": OrderStatusRefunded, "refunded_at": &tNow}, OrderStatusRefunding)
+			if updateErr != nil {
+				logger.ErrorF(ctx, "payment refund retry: failed to mark order %s refunded: %v", outTradeNo, updateErr)
 				return false, "update order status failed"
 			}
-			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
-			var proj project.Project
-			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-				if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
-					logger.ErrorF(ctx, "payment refund retry: failed to reset completed status for project %s: %v", order.ProjectID, err)
-				}
+			if !processed {
+				return true, "idempotent"
 			}
 			return true, "refund retry ok"
 		}
@@ -365,19 +359,18 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 			tNow := time.Now()
 			updates["status"] = OrderStatusRefunded
 			updates["refunded_at"] = &tNow
-			// 把 item 推回 Redis 队列恢复库存
-			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
-			var proj project.Project
-			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-				if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
-					logger.ErrorF(ctx, "payment refund: failed to reset completed status for project %s: %v", order.ProjectID, err)
-				}
+			if _, updateErr := markOrderRefundedAndReturnItem(ctx, &order, updates, OrderStatusPaid); updateErr != nil {
+				logger.ErrorF(ctx, "payment refund: failed to mark order %s refunded: %v", outTradeNo, updateErr)
+				return false, "update order status failed"
 			}
 		} else {
 			updates["status"] = OrderStatusRefunding
+			if updateErr := db.DB(ctx).Model(&PaymentOrder{}).
+				Where("out_trade_no = ? AND status = ?", outTradeNo, OrderStatusPaid).Updates(updates).Error; updateErr != nil {
+				logger.ErrorF(ctx, "payment refund: failed to mark order %s refunding: %v", outTradeNo, updateErr)
+				return false, "update order status failed"
+			}
 		}
-		db.DB(ctx).Model(&PaymentOrder{}).
-			Where("out_trade_no = ?", outTradeNo).Updates(updates)
 		// 让 epay 重试,再次进入时因状态非 PENDING 会回到 idempotent 分支
 		return false, fmt.Sprintf("fulfill failed: %v", err)
 	}

--- a/internal/apps/payment/service.go
+++ b/internal/apps/payment/service.go
@@ -325,7 +325,9 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
 			var proj project.Project
 			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-				proj.ResetCompletedStatusIfHasStock(ctx)
+				if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
+					logger.ErrorF(ctx, "payment refund retry: failed to reset completed status for project %s: %v", order.ProjectID, err)
+				}
 			}
 			return true, "refund retry ok"
 		}
@@ -367,7 +369,9 @@ func HandleNotify(ctx context.Context, q map[string]string) (bool, string) {
 			db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
 			var proj project.Project
 			if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-				proj.ResetCompletedStatusIfHasStock(ctx)
+				if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
+					logger.ErrorF(ctx, "payment refund: failed to reset completed status for project %s: %v", order.ProjectID, err)
+				}
 			}
 		} else {
 			updates["status"] = OrderStatusRefunding

--- a/internal/apps/payment/tasks.go
+++ b/internal/apps/payment/tasks.go
@@ -80,7 +80,9 @@ func expireOrder(ctx context.Context, order *PaymentOrder) {
 
 	var proj project.Project
 	if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-		proj.ResetCompletedStatusIfHasStock(ctx)
+		if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
+			logger.ErrorF(ctx, "payment cleanup: failed to reset completed status for project %s: %v", order.ProjectID, err)
+		}
 	}
 
 	logger.InfoF(ctx, "payment cleanup: order %s expired and marked as FAILED", order.OutTradeNo)

--- a/internal/apps/payment/tasks.go
+++ b/internal/apps/payment/tasks.go
@@ -61,6 +61,7 @@ func HandleExpireStaleOrders(ctx context.Context, _ *asynq.Task) error {
 // expireOrder 通过 CAS 将单笔 PENDING 订单置为 FAILED，并把预占的 item 归还 Redis。
 // 使用 CAS (WHERE status=PENDING) 保证幂等：
 //   - 若 notify 回调恰好在此同时到达并推进了状态，CAS 得 0 行，安全跳过。
+// 修复：归还 item 后，如果项目之前被标记为已完成，现在有库存了，则重置 IsCompleted。
 func expireOrder(ctx context.Context, order *PaymentOrder) {
 	rows := db.DB(ctx).Model(&PaymentOrder{}).
 		Where("out_trade_no = ? AND status = ?", order.OutTradeNo, OrderStatusPending).
@@ -76,5 +77,43 @@ func expireOrder(ctx context.Context, order *PaymentOrder) {
 	// 归还预占的 item，恢复项目库存
 	db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
 	logger.InfoF(ctx, "payment cleanup: returned item %d to project %s stock", order.ItemID, order.ProjectID)
+
+	// 检查项目是否被错误标记为已完成，如果是则重置
+	// 这种情况发生在：所有 item 被 LPOP 后某用户付款成功，项目被标记为 IsCompleted=true，
+	// 但随后其他未付款订单超时，item 被归还，此时应该重置 IsCompleted
+	resetProjectCompletedStatus(ctx, order.ProjectID)
+
 	logger.InfoF(ctx, "payment cleanup: order %s expired and marked as FAILED", order.OutTradeNo)
+}
+
+// resetProjectCompletedStatus 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted
+func resetProjectCompletedStatus(ctx context.Context, projectID string) {
+	var proj project.Project
+	if err := db.DB(ctx).Where("id = ?", projectID).First(&proj).Error; err != nil {
+		logger.ErrorF(ctx, "payment cleanup: failed to load project %s: %v", projectID, err)
+		return
+	}
+
+	// 只处理已标记为完成的项目
+	if !proj.IsCompleted {
+		return
+	}
+
+	// 检查 Redis 是否有库存
+	hasStock, err := proj.HasStock(ctx)
+	if err != nil {
+		logger.ErrorF(ctx, "payment cleanup: failed to check stock for project %s: %v", projectID, err)
+		return
+	}
+
+	// 如果有库存但项目标记为已完成，则重置
+	if hasStock {
+		if err := db.DB(ctx).Model(&project.Project{}).
+			Where("id = ? AND is_completed = ?", projectID, true).
+			Update("is_completed", false).Error; err != nil {
+			logger.ErrorF(ctx, "payment cleanup: failed to reset completed status for project %s: %v", projectID, err)
+		} else {
+			logger.InfoF(ctx, "payment cleanup: reset project %s completed status (has stock after order expiration)", projectID)
+		}
+	}
 }

--- a/internal/apps/payment/tasks.go
+++ b/internal/apps/payment/tasks.go
@@ -29,9 +29,9 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
-	"github.com/linux-do/cdk/internal/apps/project"
 	"github.com/linux-do/cdk/internal/db"
 	"github.com/linux-do/cdk/internal/logger"
+	"gorm.io/gorm"
 )
 
 // HandleExpireStaleOrders 清理长时间未付款的 PENDING 订单。
@@ -61,29 +61,37 @@ func HandleExpireStaleOrders(ctx context.Context, _ *asynq.Task) error {
 // expireOrder 通过 CAS 将单笔 PENDING 订单置为 FAILED，并把预占的 item 归还 Redis。
 // 使用 CAS (WHERE status=PENDING) 保证幂等：
 //   - 若 notify 回调恰好在此同时到达并推进了状态，CAS 得 0 行，安全跳过。
+//
 // 修复：归还 item 后，如果项目之前被标记为已完成，现在有库存了，则重置 IsCompleted。
 func expireOrder(ctx context.Context, order *PaymentOrder) {
-	rows := db.DB(ctx).Model(&PaymentOrder{}).
-		Where("out_trade_no = ? AND status = ?", order.OutTradeNo, OrderStatusPending).
-		Update("status", OrderStatusFailed).
-		RowsAffected
+	processed := false
+	if err := db.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&PaymentOrder{}).
+			Where("out_trade_no = ? AND status = ?", order.OutTradeNo, OrderStatusPending).
+			Update("status", OrderStatusFailed)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
 
-	// 另一协程（notify 回调）已处理，跳过
-	if rows == 0 {
+		if err := returnReservedItem(ctx, tx, order.ProjectID, order.ItemID); err != nil {
+			return err
+		}
+
+		processed = true
+		return nil
+	}); err != nil {
+		logger.ErrorF(ctx, "payment cleanup: failed to expire order %s: %v", order.OutTradeNo, err)
+		return
+	}
+
+	if !processed {
 		logger.InfoF(ctx, "payment cleanup: order %s already processed, skipping", order.OutTradeNo)
 		return
 	}
 
-	// 归还预占的 item，恢复项目库存
-	db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
 	logger.InfoF(ctx, "payment cleanup: returned item %d to project %s stock", order.ItemID, order.ProjectID)
-
-	var proj project.Project
-	if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
-		if err := proj.ResetCompletedStatusIfHasStock(ctx); err != nil {
-			logger.ErrorF(ctx, "payment cleanup: failed to reset completed status for project %s: %v", order.ProjectID, err)
-		}
-	}
-
 	logger.InfoF(ctx, "payment cleanup: order %s expired and marked as FAILED", order.OutTradeNo)
 }

--- a/internal/apps/payment/tasks.go
+++ b/internal/apps/payment/tasks.go
@@ -78,42 +78,10 @@ func expireOrder(ctx context.Context, order *PaymentOrder) {
 	db.Redis.RPush(ctx, project.ProjectItemsKey(order.ProjectID), order.ItemID)
 	logger.InfoF(ctx, "payment cleanup: returned item %d to project %s stock", order.ItemID, order.ProjectID)
 
-	// 检查项目是否被错误标记为已完成，如果是则重置
-	// 这种情况发生在：所有 item 被 LPOP 后某用户付款成功，项目被标记为 IsCompleted=true，
-	// 但随后其他未付款订单超时，item 被归还，此时应该重置 IsCompleted
-	resetProjectCompletedStatus(ctx, order.ProjectID)
+	var proj project.Project
+	if err := db.DB(ctx).Where("id = ?", order.ProjectID).First(&proj).Error; err == nil {
+		proj.ResetCompletedStatusIfHasStock(ctx)
+	}
 
 	logger.InfoF(ctx, "payment cleanup: order %s expired and marked as FAILED", order.OutTradeNo)
-}
-
-// resetProjectCompletedStatus 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted
-func resetProjectCompletedStatus(ctx context.Context, projectID string) {
-	var proj project.Project
-	if err := db.DB(ctx).Where("id = ?", projectID).First(&proj).Error; err != nil {
-		logger.ErrorF(ctx, "payment cleanup: failed to load project %s: %v", projectID, err)
-		return
-	}
-
-	// 只处理已标记为完成的项目
-	if !proj.IsCompleted {
-		return
-	}
-
-	// 检查 Redis 是否有库存
-	hasStock, err := proj.HasStock(ctx)
-	if err != nil {
-		logger.ErrorF(ctx, "payment cleanup: failed to check stock for project %s: %v", projectID, err)
-		return
-	}
-
-	// 如果有库存但项目标记为已完成，则重置
-	if hasStock {
-		if err := db.DB(ctx).Model(&project.Project{}).
-			Where("id = ? AND is_completed = ?", projectID, true).
-			Update("is_completed", false).Error; err != nil {
-			logger.ErrorF(ctx, "payment cleanup: failed to reset completed status for project %s: %v", projectID, err)
-		} else {
-			logger.InfoF(ctx, "payment cleanup: reset project %s completed status (has stock after order expiration)", projectID)
-		}
-	}
 }

--- a/internal/apps/payment/utils.go
+++ b/internal/apps/payment/utils.go
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 linux.do
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package payment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/linux-do/cdk/internal/apps/project"
+	"github.com/linux-do/cdk/internal/db"
+	"gorm.io/gorm"
+)
+
+// returnReservedItem 把支付预占的 item 归还 Redis，并在同一个数据库事务中重置项目完成状态。
+// Redis RPush 或项目状态更新失败时返回 error，由调用方触发外层数据库事务回滚。
+func returnReservedItem(ctx context.Context, tx *gorm.DB, projectID string, itemID uint64) error {
+	var proj project.Project
+	if err := tx.Where("id = ?", projectID).First(&proj).Error; err != nil {
+		return fmt.Errorf("load project %s: %w", projectID, err)
+	}
+	if err := db.Redis.RPush(ctx, project.ProjectItemsKey(projectID), itemID).Err(); err != nil {
+		return fmt.Errorf("return item %d to project %s stock: %w", itemID, projectID, err)
+	}
+	if err := proj.ResetCompletedStatusIfHasStock(ctx, tx); err != nil {
+		return fmt.Errorf("reset completed status for project %s: %w", projectID, err)
+	}
+	return nil
+}
+
+func markOrderRefundedAndReturnItem(ctx context.Context, order *PaymentOrder, updates map[string]any, expectedStatus OrderStatus) (bool, error) {
+	processed := false
+	err := db.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(&PaymentOrder{}).
+			Where("out_trade_no = ? AND status = ?", order.OutTradeNo, expectedStatus).
+			Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
+
+		if err := returnReservedItem(ctx, tx, order.ProjectID, order.ItemID); err != nil {
+			return err
+		}
+
+		processed = true
+		return nil
+	})
+	return processed, err
+}

--- a/internal/apps/project/models.go
+++ b/internal/apps/project/models.go
@@ -529,36 +529,25 @@ func (p *Project) GetReceivedItem(ctx context.Context, userID uint64) (*ProjectI
 	return item, nil
 }
 
-// ResetCompletedStatusIfHasStock 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted 状态。
+// ResetCompletedStatusIfHasStock 在调用方归还库存时重置项目完成状态。
 // 适用场景:
 //   - 付费订单退款成功后，item 被归还到 Redis 队列，需检查并重置项目完成状态
 //   - 付费订单超时过期后，预占的 item 被归还，需检查并重置项目完成状态
 //
-// 使用事务确保 Redis 库存检查和数据库状态更新的原子性。
-func (p *Project) ResetCompletedStatusIfHasStock(ctx context.Context) error {
-	// 只处理已标记为完成的项目
-	if !p.IsCompleted {
+// 调用方应在归还 item 的同一个数据库事务中传入 tx；
+// 若 Redis RPush 或数据库更新失败，错误会返回给外层事务处理。
+func (p *Project) ResetCompletedStatusIfHasStock(ctx context.Context, tx *gorm.DB) error {
+	hasStock, err := p.HasStock(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasStock {
 		return nil
 	}
 
-	return db.DB(ctx).Transaction(func(tx *gorm.DB) error {
-		// 检查 Redis 是否有库存
-		hasStock, err := p.HasStock(ctx)
-		if err != nil {
-			return err
-		}
-
-		// 如果有库存但项目标记为已完成，则重置
-		if hasStock {
-			if err := tx.Model(&Project{}).
-				Where("id = ? AND is_completed = ?", p.ID, true).
-				Update("is_completed", false).Error; err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
+	return tx.Model(&Project{}).
+		Where("id = ? AND is_completed = ?", p.ID, true).
+		Update("is_completed", false).Error
 }
 
 type ProjectReport struct {

--- a/internal/apps/project/models.go
+++ b/internal/apps/project/models.go
@@ -529,6 +529,38 @@ func (p *Project) GetReceivedItem(ctx context.Context, userID uint64) (*ProjectI
 	return item, nil
 }
 
+// ResetCompletedStatusIfHasStock 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted 状态。
+// 适用场景:
+//   - 付费订单退款成功后，item 被归还到 Redis 队列，需检查并重置项目完成状态
+//   - 付费订单超时过期后，预占的 item 被归还，需检查并重置项目完成状态
+//
+// 使用事务确保 Redis 库存检查和数据库状态更新的原子性。
+func (p *Project) ResetCompletedStatusIfHasStock(ctx context.Context) error {
+	// 只处理已标记为完成的项目
+	if !p.IsCompleted {
+		return nil
+	}
+
+	return db.DB(ctx).Transaction(func(tx *gorm.DB) error {
+		// 检查 Redis 是否有库存
+		hasStock, err := p.HasStock(ctx)
+		if err != nil {
+			return err
+		}
+
+		// 如果有库存但项目标记为已完成，则重置
+		if hasStock {
+			if err := tx.Model(&Project{}).
+				Where("id = ? AND is_completed = ?", p.ID, true).
+				Update("is_completed", false).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
 type ProjectReport struct {
 	ID         uint64    `json:"id" gorm:"primaryKey,autoIncrement"`
 	ProjectID  string    `json:"project_id" gorm:"size:64;index;uniqueIndex:idx_project_reporter"`

--- a/internal/apps/project/utils.go
+++ b/internal/apps/project/utils.go
@@ -169,6 +169,7 @@ func ListMyProjectsWithTags(ctx context.Context, creatorID uint64, offset, limit
 	}, nil
 }
 
+// maxProjectPrice 付费项目的最大单价上限
 var maxProjectPrice = decimal.RequireFromString("99999999.99")
 
 // validateProjectPrice 校验 Price 字段合法性。

--- a/internal/apps/project/utils.go
+++ b/internal/apps/project/utils.go
@@ -205,3 +205,27 @@ func validateProjectPrice(ctx context.Context, price decimal.Decimal, dt Distrib
 	}
 	return nil
 }
+
+// ResetCompletedStatusIfHasStock 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted 状态。
+// 适用场景:
+//   - 付费订单退款成功后，item 被归还到 Redis 队列，需检查并重置项目完成状态
+//   - 付费订单超时过期后，预占的 item 被归还，需检查并重置项目完成状态
+func (p *Project) ResetCompletedStatusIfHasStock(ctx context.Context) {
+	// 只处理已标记为完成的项目
+	if !p.IsCompleted {
+		return
+	}
+
+	// 检查 Redis 是否有库存
+	hasStock, err := p.HasStock(ctx)
+	if err != nil {
+		return
+	}
+
+	// 如果有库存但项目标记为已完成，则重置
+	if hasStock {
+		db.DB(ctx).Model(&Project{}).
+			Where("id = ? AND is_completed = ?", p.ID, true).
+			Update("is_completed", false)
+	}
+}

--- a/internal/apps/project/utils.go
+++ b/internal/apps/project/utils.go
@@ -169,7 +169,6 @@ func ListMyProjectsWithTags(ctx context.Context, creatorID uint64, offset, limit
 	}, nil
 }
 
-// maxProjectPrice 付费项目的最大单价上限
 var maxProjectPrice = decimal.RequireFromString("99999999.99")
 
 // validateProjectPrice 校验 Price 字段合法性。
@@ -204,28 +203,4 @@ func validateProjectPrice(ctx context.Context, price decimal.Decimal, dt Distrib
 		return errors.New(CreatorNotConfigured)
 	}
 	return nil
-}
-
-// ResetCompletedStatusIfHasStock 检查项目是否有库存但被标记为已完成，如果是则重置 IsCompleted 状态。
-// 适用场景:
-//   - 付费订单退款成功后，item 被归还到 Redis 队列，需检查并重置项目完成状态
-//   - 付费订单超时过期后，预占的 item 被归还，需检查并重置项目完成状态
-func (p *Project) ResetCompletedStatusIfHasStock(ctx context.Context) {
-	// 只处理已标记为完成的项目
-	if !p.IsCompleted {
-		return
-	}
-
-	// 检查 Redis 是否有库存
-	hasStock, err := p.HasStock(ctx)
-	if err != nil {
-		return
-	}
-
-	// 如果有库存但项目标记为已完成，则重置
-	if hasStock {
-		db.DB(ctx).Model(&Project{}).
-			Where("id = ? AND is_completed = ?", p.ID, true).
-			Update("is_completed", false)
-	}
 }


### PR DESCRIPTION
## Problem

When users reserve paid CDK items but don't complete payment, the following issue occurs:

1. User reserves an item → item is LPOPed from Redis
2. All items are reserved → Redis stock becomes 0
3. One user completes payment → project is marked as `IsCompleted=true`
4. Other orders expire after 15 minutes → items are RPushed back to Redis
5. **Issue**: `IsCompleted` remains `true` even though Redis has stock again
6. **Result**: Frontend shows "Project Completed" and users cannot claim available items

**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- x 我已阅读并理解 [贡献者公约](https://github.com/linux-do/cdk/blob/master/CODE_OF_CONDUCT.md)，  
- x 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/cdk/blob/master/CLA.md)，确认我的贡献将根据项目的 MIT 许可证进行许可，  
- x 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并，

## Root Cause

- `FulfillForReceiver()` sets `IsCompleted=true` when Redis stock is 0
- `expireOrder()` returns items to Redis but doesn't reset `IsCompleted`
- Frontend checks `is_completed` field and disables the claim button
- Backend only checks Redis stock in `IsReceivable()`, not `IsCompleted`

## Solution

Added logic to check and reset `IsCompleted` when items are returned to inventory:

### Changes

1. **tasks.go**: Added `resetProjectCompletedStatus()` 
   - Called after `expireOrder()` returns items to Redis
   - Checks if project has `IsCompleted=true` but Redis has stock
   - Resets `IsCompleted=false` if condition met

2. **service.go**: Added `resetProjectCompletedStatusAfterRefund()`
   - Called when refund succeeds and items are returned
   - Handles both immediate refund and retry scenarios
   - Same logic as expiration cleanup

### Testing

- ✅ Compiled successfully without errors
- ✅ Logic verified for both expiration and refund paths
- ✅ CAS update with WHERE clause ensures idempotency

## Impact

- Projects will correctly show as available after expired orders release items
- No breaking changes to existing functionality
- Minimal performance impact (one query per expired order)

Fixes the issue where legitimate users cannot claim items that become available after order expiration.